### PR TITLE
Fixes dataset naming issue and iteration counter

### DIFF
--- a/eggplant/methods.py
+++ b/eggplant/methods.py
@@ -448,10 +448,10 @@ def fa_transfer_to_reference(
         names = list(adatas.keys())
         objs = list(adatas.values())
     elif isinstance(adatas, list):
-        names = None
+        names = [f"Model_{k}" for k in range(len(adatas))]
         objs = adatas
     else:
-        names = None
+        names = [f"Model_{k}" for k in range(len(adatas))]
         objs = [adatas]
 
     objs_order = dict()
@@ -463,7 +463,7 @@ def fa_transfer_to_reference(
         obj_iterator = enumerate(objs)
 
     for k, obj in obj_iterator:
-        print(msg.format(k, k, len(objs)), flush=True)
+        print(msg.format(k, k+1, len(objs)), flush=True)
         if "pca" not in obj.uns.keys():
             if n_components is None:
                 n_comps = min(n_comps_start, len(obj) - 1, obj.shape[1] - 1)


### PR DESCRIPTION
In "fa_transfer_to_reference()"
- The variable 'names' was set to None, to it was crashing unnamed AnnData dictionaries or lists because it took the default name "Model_0" from "transfer_to_reference()", making all datasets with the same model names.
- the line 'msg.format(model_name, k + 1, n_adatas)' was missing the '+1'. It was showing 0/2 complete and 1/2 complete, and it should be 1/2 and 2/2.